### PR TITLE
make FinallyDelegate more resilient regarding unhandled exceptions

### DIFF
--- a/NUnitLite-1.0.0/src/framework/FinallyDelegate.cs
+++ b/NUnitLite-1.0.0/src/framework/FinallyDelegate.cs
@@ -29,9 +29,18 @@ using System.Diagnostics;
 using System.Threading;
 using NUnit.Framework.Api;
 using System.Collections.Generic;
+using System.Runtime.Remoting.Messaging;
 
 namespace NUnit.Framework.Internal
 {
+	[Serializable]
+	class Container : ILogicalThreadAffinative {
+		public string testName;
+		public Container(string testName) {
+			this.testName = testName;
+		}
+	}
+
 	public class FinallyDelegate
 	{
 		// If our test spawns a thread that throws, we will bubble
@@ -49,19 +58,31 @@ namespace NUnit.Framework.Internal
 		// so we need a stack of finally delegate continuations
 		Stack<Tuple<TestExecutionContext, long, TestResult>> testStack;
 
+		Dictionary<string, TestResult> lookupTable;
+
+		private static readonly string CONTEXT_KEY = "TestResultName";
+
 		public FinallyDelegate () {
 			this.testStack = new Stack<Tuple<TestExecutionContext, long, TestResult>>();
+			this.lookupTable = new Dictionary<string, TestResult>();
 		}
 
 		public void Set (TestExecutionContext context, long startTicks, TestResult result) {
 			var frame = new Tuple<TestExecutionContext, long, TestResult>(context, startTicks, result);
+
+			/* keep name in LogicalCallContext, because this will be inherited by
+			 * Threads spawned by the test case */
+			CallContext.SetData(CONTEXT_KEY, new Container(result.Test.FullName));
+
+			this.lookupTable.Add(result.Test.FullName, result);
 			this.testStack.Push(frame);
 		}
 
 		public void HandleUnhandledExc (Exception ex) {
-			TestExecutionContext context = this.testStack.Peek().Item1;
-			context.CurrentResult.RecordException(ex);
-			context.CurrentResult.ThreadCrashFail = true;
+			Container c = (Container) CallContext.GetData(CONTEXT_KEY);
+			TestResult result = this.lookupTable [c.testName];
+			result.RecordException(ex);
+			result.ThreadCrashFail = true;
 		}
 
 		public void Complete () {

--- a/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs
+++ b/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs
@@ -181,6 +181,15 @@ namespace NUnit.Framework.Internal.WorkItems
 
         private void RunTest()
         {
+            /* using a separate ExecutionContext for every test case,
+             * guarantees us to have a dedicated "namespace" for the
+             * LogicalCallContext per testcase */
+            ExecutionContext ec = ExecutionContext.Capture().CreateCopy();
+            ExecutionContext.Run(ec, DispatchWork, null);
+        }
+
+        private void DispatchWork(object o)
+        {
             _context.CurrentTest = this.Test;
             _context.CurrentResult = this.Result;
             _context.Listener.TestStarted(this.Test);

--- a/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs
+++ b/NUnitLite-1.0.0/src/framework/Internal/WorkItems/WorkItem.cs
@@ -184,7 +184,7 @@ namespace NUnit.Framework.Internal.WorkItems
             /* using a separate ExecutionContext for every test case,
              * guarantees us to have a dedicated "namespace" for the
              * LogicalCallContext per testcase */
-            ExecutionContext ec = ExecutionContext.Capture().CreateCopy();
+            ExecutionContext ec = ExecutionContext.Capture();
             ExecutionContext.Run(ec, DispatchWork, null);
         }
 


### PR DESCRIPTION
The idea of `FinallyDelegate` is to capture exceptions that aren't
caught by the testcase. In order to realize that, it registers a handler
in the current appdomain. In case the handler is executed, it gets the
right context by relying on the fact that the testcase calls a `Set()`
method, which pushes the necessary context on a stack. After completion
of the testcase, `Complete()` is called and thus the context is removed
from the stack. (NB: TestResults can be nested, thus a stack
datastructure makes sense here).

Now consider the following scenario:

Testcase A is spawning another ThreadX, and ThreadX is throwing an
exception. The order of things can be like this:

* TestcaseA does `FinallyDelegate.Set()`
* TestcaseA executes
* ThreadX spawns
* TestcaseA finishes and calls `FinallyDelegate.Complete()`
* ThreadX throws exception and thus using the wrong context to report the error

In the last step three things can happen:

(1) Top of the stack is the "testsuite result" and records an error in the
    test suite. It is then really just marked as "failed", but it doesn't
    tell _what_ testcases failed. This ends up being confusing, as the test
    harness doesn't show any errors, but still returns with a non-zero exit
    code. For example that happend here
    https://github.com/mono/mono/pull/5911#issuecomment-341194418
    and here:
    https://jenkins.mono-project.com/job/test-mono-pull-request-arm64/5877/

(2) Top of the stack is another testcase, and consequently the error
    will be reported for the wrong testcase. Not nice.

(3) Stack is empty, and thus it would end in a NRE. I haven't seen this
    one yet.

That's about the state of affairs. How to solve this?

Thanks to @luhenry who pointed me to the right direction: We going to
use less-known feature called `ExecutionContext`. An `ExecutionContext`
is bound to managed thread. It has something called
`LogicalCallContext`, which has an interesting property: If a newly
Thread is created, it also gets a new `ExecutionContext` associated with
it, BUT ALSO inherits the `LogicalCallContext` from the calling thread.
We going to take advantage of this fact, and create explicitly a new
`ExecutionContext` for each test. That way, we can store the necessary
information in the `LogicalCallContext`, so that unhandled exceptions
can be assigned to the correct `TestResult` object by the
`FinallyDelegate`.