### PR TITLE
[FinallyDelegate] make key for `lookupTable` actually unique

### DIFF
--- a/NUnitLite-1.0.0/src/framework/FinallyDelegate.cs
+++ b/NUnitLite-1.0.0/src/framework/FinallyDelegate.cs
@@ -35,9 +35,9 @@ namespace NUnit.Framework.Internal
 {
 	[Serializable]
 	class Container : ILogicalThreadAffinative {
-		public string testName;
-		public Container(string testName) {
-			this.testName = testName;
+		public Guid guid;
+		public Container(Guid guid) {
+			this.guid = guid;
 		}
 	}
 
@@ -58,30 +58,30 @@ namespace NUnit.Framework.Internal
 		// so we need a stack of finally delegate continuations
 		Stack<Tuple<TestExecutionContext, long, TestResult>> testStack;
 
-		Dictionary<string, TestResult> lookupTable;
+		Dictionary<Guid, TestResult> lookupTable;
 
 		private static readonly string CONTEXT_KEY = "TestResultName";
 
 		public FinallyDelegate () {
 			this.testStack = new Stack<Tuple<TestExecutionContext, long, TestResult>>();
-			this.lookupTable = new Dictionary<string, TestResult>();
+			this.lookupTable = new Dictionary<Guid, TestResult>();
 		}
 
 		public void Set (TestExecutionContext context, long startTicks, TestResult result) {
 			var frame = new Tuple<TestExecutionContext, long, TestResult>(context, startTicks, result);
 
-			var name = result.FullName + "_" + result.Test.FullName + "_" + result.GetHashCode ();
 			/* keep name in LogicalCallContext, because this will be inherited by
 			 * Threads spawned by the test case */
-			CallContext.SetData(CONTEXT_KEY, new Container(name));
+			var guid = Guid.NewGuid();
+			CallContext.SetData(CONTEXT_KEY, new Container(guid));
 
-			this.lookupTable.Add(name, result);
+			this.lookupTable.Add(guid, result);
 			this.testStack.Push(frame);
 		}
 
 		public void HandleUnhandledExc (Exception ex) {
 			Container c = (Container) CallContext.GetData(CONTEXT_KEY);
-			TestResult result = this.lookupTable [c.testName];
+			TestResult result = this.lookupTable [c.guid];
 			result.RecordException(ex);
 			result.ThreadCrashFail = true;
 		}

--- a/NUnitLite-1.0.0/src/framework/FinallyDelegate.cs
+++ b/NUnitLite-1.0.0/src/framework/FinallyDelegate.cs
@@ -70,11 +70,12 @@ namespace NUnit.Framework.Internal
 		public void Set (TestExecutionContext context, long startTicks, TestResult result) {
 			var frame = new Tuple<TestExecutionContext, long, TestResult>(context, startTicks, result);
 
+			var name = result.FullName + "_" + result.Test.FullName + "_" + result.GetHashCode ();
 			/* keep name in LogicalCallContext, because this will be inherited by
 			 * Threads spawned by the test case */
-			CallContext.SetData(CONTEXT_KEY, new Container(result.Test.FullName));
+			CallContext.SetData(CONTEXT_KEY, new Container(name));
 
-			this.lookupTable.Add(result.Test.FullName, result);
+			this.lookupTable.Add(name, result);
 			this.testStack.Push(frame);
 		}
 


### PR DESCRIPTION
Attributes like `[TestCase]` execute the same test method multiple
times, therefore there could be a clash in `lookupTable` when adding
more elements to it.