### PR TITLE
src/framework: Build FinallyDelegate

### DIFF
--- a/NUnitLite-1.0.0/src/framework/nunitlite-2.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-2.0.csproj
@@ -247,6 +247,7 @@
     <Compile Include="Extensibility\ISuiteBuilder.cs" />
     <Compile Include="Extensibility\ITestCaseBuilder.cs" />
     <Compile Include="Extensibility\ITestCaseProvider.cs" />
+    <Compile Include="FinallyDelegate.cs" />
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Has.cs" />

--- a/NUnitLite-1.0.0/src/framework/nunitlite-3.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-3.5.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Extensibility\ITestCaseBuilder.cs" />
     <Compile Include="Extensibility\ITestCaseProvider.cs" />
     <Compile Include="GlobalSettings.cs" />
+    <Compile Include="FinallyDelegate.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Has.cs" />
     <Compile Include="IExpectException.cs" />

--- a/NUnitLite-1.0.0/src/framework/nunitlite-4.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-4.0.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Extensibility\ITestCaseBuilder.cs" />
     <Compile Include="Extensibility\ITestCaseProvider.cs" />
     <Compile Include="GlobalSettings.cs" />
+    <Compile Include="FinallyDelegate.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Has.cs" />
     <Compile Include="IExpectException.cs" />

--- a/NUnitLite-1.0.0/src/framework/nunitlite-4.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-4.5.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Extensibility\ISuiteBuilder.cs" />
     <Compile Include="Extensibility\ITestCaseBuilder.cs" />
     <Compile Include="Extensibility\ITestCaseProvider.cs" />
+    <Compile Include="FinallyDelegate.cs" />
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Has.cs" />


### PR DESCRIPTION
While working on porting the build dependencies for a local build of MonoDevelop -- ideally, as may be pursuant towards developing a contrib. port for supporting MonoDevelop under pkgsrc (wip ports) -- I'd made this patch. This patch may be used in a port for NUnitLite under pkgsrc wip ports, at some future time. I thought it might be helpful, to share this patch with the upstream source repository, as well as applying it locally. 

This patch has been tested in a NUnitLite build -- built as using a locally built MSBuild, juxtaposed to building NUnitLite under a local port for NAnt -- built under Mono 6.4.0.198 in a local Mono build with local patches to the pkgsrc lang/mono6 port, in that much using pkgsrc ports on FreeBSD 11.2

Original changeset message:

The class FinallyDelegate was added in changeset
88c3edc80cc1172ecd91a4c0e9d3269b4c9e0928

This patch ensures that the class will be built with MSBuild under
NUnitLite, for frameworks 2.0, 3.5, 4.0, and 4.5
