### PR TITLE
src/**/*.csproj: Define CodeAnalysisRuleSet conditionally

### DIFF
--- a/NUnitLite-1.0.0/src/TestResultConsole/TestResultConsole.csproj
+++ b/NUnitLite-1.0.0/src/TestResultConsole/TestResultConsole.csproj
@@ -40,7 +40,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -49,7 +49,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/NUnitLite-1.0.0/src/framework/nunitlite-2.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-2.0.csproj
@@ -40,7 +40,7 @@
     <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\..\bin\Debug\net-2.0\nunitlite.xml</DocumentationFile>
     <OutputPath>..\..\bin\Debug\net-2.0\</OutputPath>
   </PropertyGroup>
@@ -50,7 +50,7 @@
     <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\..\bin\Release\net-2.0\nunitlite.xml</DocumentationFile>
     <OutputPath>..\..\bin\Release\net-2.0\</OutputPath>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-3.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-3.5.csproj
@@ -42,7 +42,7 @@
     <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\..\bin\Debug\net-3.5\nunitlite.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -52,7 +52,7 @@
     <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\..\bin\Release\net-3.5\nunitlite.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-4.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-4.0.csproj
@@ -42,7 +42,7 @@
     <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\..\bin\Debug\net-4.0\nunitlite.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -52,7 +52,7 @@
     <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\..\bin\Release\net-4.0\nunitlite.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-4.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-4.5.csproj
@@ -42,7 +42,7 @@
     <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\..\bin\Debug\net-4.5\nunitlite.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
@@ -53,7 +53,7 @@
     <DefineConstants>TRACE;NET_4_5, CLR_4_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\..\bin\Release\net-4.5\nunitlite.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-3.5.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-3.5.csproj
@@ -42,7 +42,7 @@
     <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -51,7 +51,7 @@
     <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.0.csproj
@@ -42,7 +42,7 @@
     <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -51,7 +51,7 @@
     <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.5.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.5.csproj
@@ -42,7 +42,7 @@
     <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -52,7 +52,7 @@
     <DefineConstants>TRACE;NET_4_5,CLR_4_0,NUNITLITE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(RunCodeAnalysis)' != 'false'">AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
When building NUnitLite under MSBuild with some Mono installations, it may be possible to prevent a number of warning messages by defining a conditional constraint on the `CodeAnalysisRuleSet` property in NUnitLite `*.csproj` files. 

A change similar to this patch, along with https://github.com/mono/NUnitLite/pull/21 may be applied in a port for NUnitLite -- specifically, in using Mono as a CLR environment -- to be contributed under pkgsrc 'wip' ports.

Sourcing the original changelog message:

This patch may serve to work around a matter of the availability of
the file `AllRules.ruleset`, such that may not exist under some MSBuild
installations, This workaround, as such, may be applied in a manner as
follows, namely in disabling the RunCodeAnalysis property when building
NUnitLite under MSBuild.

~~~~
msbuild NUnitLite-1.0.0/src/framework/nunitlite-4.5.csproj /p:RunCodeAnalysis=false
~~~~

This may serve to prevent a number of warning messages, when building
NUnitLite under MSBuild with some Mono installations.

This patch provides, in effect, a conditional evaluation for the
declaration of the CodeAnalysisRuleSet property in NUnitLite *.csproj
files.