### PR TITLE
src/**/*.csproj: Use AppendConstants within DefineConstants declarations

### DIFF
--- a/NUnitLite-1.0.0/src/TestResultConsole/TestResultConsole.csproj
+++ b/NUnitLite-1.0.0/src/TestResultConsole/TestResultConsole.csproj
@@ -37,7 +37,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -46,7 +46,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-2.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-2.0.csproj
@@ -37,7 +37,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -47,7 +47,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-3.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-3.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -49,7 +49,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-4.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-4.0.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -49,7 +49,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-4.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-4.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -50,7 +50,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NET_4_5, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_5, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-netcf-2.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-netcf-2.0.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -38,7 +38,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-netcf-3.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-netcf-3.5.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -38,7 +38,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-sl-3.0.csproj
@@ -32,7 +32,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -43,7 +43,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-sl-4.0.csproj
@@ -30,7 +30,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-sl-5.0.csproj
@@ -31,7 +31,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_4_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_4_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -42,7 +42,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-2.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-2.0.csproj
@@ -20,14 +20,14 @@
     <DebugType>full</DebugType>
     <OutputPath>..\..\bin\Debug\net-2.0\</OutputPath>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;CLR_2_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;CLR_2_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;CLR_2_0</DefineConstants>
+    <DefineConstants>TRACE;CLR_2_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Release\net-2.0\</OutputPath>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-3.5.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-3.5.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;CLR_2_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;CLR_2_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;CLR_2_0</DefineConstants>
+    <DefineConstants>TRACE;CLR_2_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-4.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-4.0.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;CLR_4_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;CLR_4_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;CLR_4_0</DefineConstants>
+    <DefineConstants>TRACE;CLR_4_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-4.5.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-4.5.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;CLR_4_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;CLR_4_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;CLR_4_0</DefineConstants>
+    <DefineConstants>TRACE;CLR_4_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-netcf-2.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-netcf-2.0.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-netcf-3.5.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-netcf-3.5.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-3.0.csproj
@@ -32,7 +32,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -42,7 +42,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-4.0.csproj
@@ -30,7 +30,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -40,7 +40,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-5.0.csproj
@@ -31,7 +31,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-3.0.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-4.0.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-5.0.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-2.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-2.0.csproj
@@ -38,7 +38,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Debug\net-2.0\</OutputPath>
@@ -46,7 +46,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Release\net-2.0\</OutputPath>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-3.5.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-3.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -47,7 +47,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-4.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-4.0.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -47,7 +47,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-4.5.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-4.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_5,CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_5,CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -48,7 +48,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NET_4_5,CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_5,CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-netcf-2.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-netcf-2.0.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-2.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-netcf-3.5.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-netcf-3.5.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-3.0.csproj
@@ -32,7 +32,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -42,7 +42,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-4.0.csproj
@@ -30,7 +30,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -40,7 +40,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-5.0.csproj
@@ -31,7 +31,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-2.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-2.0.csproj
@@ -37,7 +37,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Debug\net-2.0\</OutputPath>
@@ -45,7 +45,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Release\net-2.0\</OutputPath>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-3.5.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-3.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -48,7 +48,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.0.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -48,7 +48,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.5.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -49,7 +49,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NET_4_5,CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_5,CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-netcf-2.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-netcf-2.0.csproj
@@ -27,7 +27,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -39,7 +39,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-2.0\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-netcf-3.5.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-netcf-3.5.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-3.0.csproj
@@ -44,7 +44,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -54,7 +54,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-4.0.csproj
@@ -57,7 +57,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_4_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_4_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -67,7 +67,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-5.0.csproj
@@ -58,7 +58,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;CLR_4_0;SL_5_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;CLR_4_0;SL_5_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -68,7 +68,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;CLR_4_0;SL_5_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;CLR_4_0;SL_5_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
The NUnitLite src includes a number of uses of a preprocessor symbol, `MONO`.

This changeset may serve in a manner of an approach for building NUnitLite -- under MSBuild -- with the `MONO` symbol declared in `DefineConstants` for the build, without overriding the `DefineConstants` declarations provided in the respective `*.csproj` files. The approach entails adding, simply, an AppendConstants reference into the respective `DefineConstants` declarations

**Of course, this in itself may serve to cause a build failure** in some builds under Mono, when building with `/p:AppendConstants=MONO` such as in the following:

~~~~
Runner/TextUI.cs(257,34): error CS0103: The name 'Xamarin' does not exist in the current context 
~~~~

To that effect, it seems that an assembly `Xamarin.BabysitterSupport` is being referenced in all instances of the `MONO` constant. 

Perhaps there may be a way to auto-detect when the build is being produced under a Xamarin environment? subsequently, to conditionally enable those sections exclusively under Xamarin, through any combination of additional MSBuild XML declarations and preprocessor symbols. 

I'm not immediately familiar with Xamarin extensions under MS VC or any other platform, per se. Perhaps the `Xamarin.BabysitterSupport` assembly may be available in those extensions, presently? If there may be any way to conditionally detect the availability of that extension, perhaps it could be added to the build configuration such as to prevent that build error while still providing support for uses of `Xamarin.BabysitterSupport` . Alternately, one could propose to patch the source code by simply removing those sections, during any single build.

A changeset including the changes made in this patch -- as well as those in https://github.com/mono/NUnitLite/pull/22 and https://github.com/mono/NUnitLite/pull/21 -- may be featured in a port for NUnitLite with Mono, to be contributed under pkgsrc 'wip' ports. This port may not provide support for applications of `Xamarin.BabysitterSupport` in NUnitLite.

Original changelog message:

This patch provides support for an AppendContants build parameter, in
NUnitLite under MSBuild. This allows for building with such as the
following build options, under Mono:

~~~~
msbuild src/framework/nunitlite-4.5.csproj \
  /p:AppendConstants=MONO \
  /restore /t:build /p:CscToolPath=${PREFIX}/lib/mono/4.5/ \
  /p:TargetFrameworkVersion=4.7.2 /p:SignAssembly=false /v:detailed
~~~~

To some extent, this may serve to emulate some of the build
configuration under NAnt.