### PR TITLE
TextUI.cs: Patch for Mono environments absent of nunit24, xunit

### DIFF
--- a/NUnitLite-1.0.0/src/TestResultConsole/TestResultConsole.csproj
+++ b/NUnitLite-1.0.0/src/TestResultConsole/TestResultConsole.csproj
@@ -37,7 +37,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -46,7 +46,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/Runner/TextUI.cs
+++ b/NUnitLite-1.0.0/src/framework/Runner/TextUI.cs
@@ -253,7 +253,7 @@ namespace NUnitLite.Runner
                                 filter = new AndFilter(filter, excludeFilter);
                         }
 
-#if MONO
+#if (MONO && !MONO_NO_NUNIT24)
                         filter = Xamarin.BabysitterSupport.AddBabysitterFilter(filter);
 #endif
                         RunTests(filter);
@@ -372,7 +372,7 @@ namespace NUnitLite.Runner
                     new NUnit2XmlOutputWriter(startTime).WriteResultFile(result, resultFile);
                 else if (resultFormat == "nunit3")
                     new NUnit3XmlOutputWriter(startTime).WriteResultFile(result, resultFile);
-#if MONO
+#if (MONO && !MONO_NO_XUNIT)
                 else if (resultFormat == "xunit")
                     new XunitXmlOutputWriter(startTime).WriteResultFile(result, resultFile);
 #endif
@@ -422,7 +422,7 @@ namespace NUnitLite.Runner
         /// <param name="test">The test</param>
         public void TestStarted(ITest test)
         {
-#if MONO
+#if (MONO && !MONO_NO_NUNIT24)
             if (!test.IsSuite)
                 Xamarin.BabysitterSupport.RecordEnterTest(test.FullName);
 
@@ -442,7 +442,7 @@ namespace NUnitLite.Runner
         /// <param name="result">The result of the test</param>
         public void TestFinished(ITestResult result)
         {
-#if MONO
+#if (MONO && !MONO_NO_NUNIT24)
             if (!result.Test.IsSuite) {
                 Xamarin.BabysitterSupport.RecordLeaveTest (result.Test.FullName);
                 if (result.ResultState.Status == TestStatus.Failed)

--- a/NUnitLite-1.0.0/src/framework/nunitlite-2.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-2.0.csproj
@@ -37,7 +37,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -47,7 +47,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-3.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-3.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -49,7 +49,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-4.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-4.0.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -49,7 +49,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-4.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-4.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -50,7 +50,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NET_4_5, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_5, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-netcf-2.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-netcf-2.0.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -38,7 +38,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-netcf-3.5.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-netcf-3.5.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -38,7 +38,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-sl-3.0.csproj
@@ -32,7 +32,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -43,7 +43,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-sl-4.0.csproj
@@ -30,7 +30,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/framework/nunitlite-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/framework/nunitlite-sl-5.0.csproj
@@ -31,7 +31,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_4_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_4_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -42,7 +42,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-2.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-2.0.csproj
@@ -20,14 +20,14 @@
     <DebugType>full</DebugType>
     <OutputPath>..\..\bin\Debug\net-2.0\</OutputPath>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;CLR_2_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;CLR_2_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;CLR_2_0</DefineConstants>
+    <DefineConstants>TRACE;CLR_2_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Release\net-2.0\</OutputPath>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-3.5.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-3.5.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;CLR_2_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;CLR_2_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;CLR_2_0</DefineConstants>
+    <DefineConstants>TRACE;CLR_2_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-4.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-4.0.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;CLR_4_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;CLR_4_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;CLR_4_0</DefineConstants>
+    <DefineConstants>TRACE;CLR_4_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-4.5.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-4.5.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;CLR_4_0</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;CLR_4_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;CLR_4_0</DefineConstants>
+    <DefineConstants>TRACE;CLR_4_0;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-netcf-2.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-netcf-2.0.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-netcf-3.5.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-netcf-3.5.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-3.0.csproj
@@ -32,7 +32,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -42,7 +42,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-4.0.csproj
@@ -30,7 +30,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -40,7 +40,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/mock-assembly/mock-assembly-sl-5.0.csproj
@@ -31,7 +31,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-3.0.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-4.0.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/runner/ci-test-runner-sl-5.0.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-2.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-2.0.csproj
@@ -38,7 +38,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Debug\net-2.0\</OutputPath>
@@ -46,7 +46,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Release\net-2.0\</OutputPath>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-3.5.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-3.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -47,7 +47,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-4.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-4.0.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -47,7 +47,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-4.5.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-4.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_5,CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_5,CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -48,7 +48,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NET_4_5,CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_5,CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-netcf-2.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-netcf-2.0.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-2.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-netcf-3.5.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-netcf-3.5.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-3.0.csproj
@@ -32,7 +32,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -42,7 +42,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-4.0.csproj
@@ -30,7 +30,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -40,7 +40,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/testdata/nunitlite.testdata-sl-5.0.csproj
@@ -31,7 +31,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_5_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-2.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-2.0.csproj
@@ -37,7 +37,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Debug\net-2.0\</OutputPath>
@@ -45,7 +45,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_2_0,CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputPath>..\..\bin\Release\net-2.0\</OutputPath>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-3.5.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-3.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -48,7 +48,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-3.5\</OutputPath>
-    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_3_5, CLR_2_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.0.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -48,7 +48,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.0\</OutputPath>
-    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_0, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.5.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-4.5.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET_4_5, CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -49,7 +49,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\net-4.5\</OutputPath>
-    <DefineConstants>TRACE;NET_4_5,CLR_4_0,NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;NET_4_5,CLR_4_0,NUNITLITE;$(AppendConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-netcf-2.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-netcf-2.0.csproj
@@ -27,7 +27,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-2.0</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -39,7 +39,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-2.0\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_2_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-netcf-3.5.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-netcf-3.5.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\netcf-3.5\</OutputPath>
-    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;WindowsCE;NETCF;NETCF_3_5;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-3.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-3.0.csproj
@@ -44,7 +44,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -54,7 +54,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-3.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_3_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-4.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-4.0.csproj
@@ -57,7 +57,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_4_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;SL_4_0;CLR_4_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -67,7 +67,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-4.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;SL_4_0;CLR_2_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>

--- a/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-5.0.csproj
+++ b/NUnitLite-1.0.0/src/tests/nunitlite.tests-sl-5.0.csproj
@@ -58,7 +58,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;CLR_4_0;SL_5_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT;CLR_4_0;SL_5_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
@@ -68,7 +68,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release\sl-5.0\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT;CLR_4_0;SL_5_0;NUNITLITE</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT;CLR_4_0;SL_5_0;NUNITLITE;$(AppendConstants)</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
This patch incorporates the changeset published under https://github.com/mono/NUnitLite/pull/23

Original log message, for the newer changeset of the two:

TextUI.cs: Patch for Mono environments absent of nunit24, xunit

This patch extends on a patch published in an earlier branch, available
via contrib under the branch ci/patch-append-constants in changeset 9d3568e

Concerning nunit24 support for Mono in NUnitLite, the nunit24 BabySitter
class was removed from the Mono mcs source tree, in Mono 6.6.0.161
mono/mono@55fbd14

Concering xunit support for Mono in NUnitLite, the mono xunit-binaries
external may not be available under some Mono installations.

This changeset applies a couple of additional preprocessor declarations
in NUnitLite TextUI.cs, such that may serve to allow for building in a
Mono environment without nunit24 support and/or without xunit support,
vis a vis
MONO_NO_NUNIT24
MONO_NO_XUNIT

This may be applied with such as the following msbuild cmd - noting the
particular syntax for providing a sequence of constant symbols in
AppendConstants, namely double quoting the value as delimited with comma
characters, such that may be supported in UNIX-like shell environments:

~~~~
msbuild src/framework/nunitlite-4.5.csproj /restore /t:build \
 /p:CscToolPath=/usr/pkg/lib/mono/4.5/ /p:SignAssembly=false /v:detailed \
 /p:RunCodeAnalysis=false /p:TargetFrameworkVersion=4.7.2 \
 /p:AppendConstants=\"MONO,MONO_NO_NUNIT24,MONO_NO_XUNIT\"
~~~~

This may serve to prevent a build failure, such that may otherwise occur
while compiling TextUI.cs when the MONO symbol is declared in the
compiler environment.

For Mono environments in which the xunit assemblies may be available,
of course the MONO_NO_XUNIT symbol may be removed from the declaration
of the AppendConstants property. The similar would apply, repectively,
for any Mono environment in which the original nunit24 support may be
available.

For purposes of ensuring backwards compatibility, by default, the build
under MONO would be produced as in the original behavior, i.e assuming
nunit24 and xunit would both be available in the build environment.
